### PR TITLE
Make STATA dependencies optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,6 @@ requires-python = ">=3.9"
 dependencies = [
     'PyYAML',
     'pandas>=2',
-    'pystata',
-    'stata-setup',
     'data-bridges-client @ git+https://github.com/WFP-VAM/DataBridgesAPI.git',
 ]
 


### PR DESCRIPTION
This PR moves the dependencies needed for STATA functionality into optional dependencies. 

- This allows the package to be used by downstream python-only applications without needed to also install packages that are needed for STATA. 
- Downstream applications needing the STATA function will need to install the package with the additional component, ie `data-bridges-knots[STATA]`