### PR TITLE
Pin to supported pandas version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.10"
 
 dependencies = [
     'PyYAML',
-    'pandas>=2',
+    'pandas==2.3.3',
     'data-bridges-client @ git+https://github.com/WFP-VAM/DataBridgesAPI.git',
 ]
 


### PR DESCRIPTION
## Description

DataBridgesKnots does not work with the latest version of Pandas 3.0.0. I'm not quite sure why, but we started experiencing errors in the JOR Data Quality App due to the pipeline installing Pandas 3.0: https://github.com/WFP-VAM/JOR-data-quality-automation/issues/31

We could reproduce the error and trace it to Pandas 3.0. I'm not sure what changed but the data type returned when using if in conjunction with R is no longer a `list` or a `data.frame`. This was causing our application to break.

Pinning our requirements to `pandas==2.3.3` worked.

## Related Issue

https://github.com/WFP-VAM/JOR-data-quality-automation/issues/31

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ x ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
