### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   bump-version:
     if: "!startsWith(github.event.head_commit.message, 'bump:')"


### PR DESCRIPTION
Potential fix for [https://github.com/WFP-VAM/DataBridgesKnots/security/code-scanning/1](https://github.com/WFP-VAM/DataBridgesKnots/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/semver.yml` so the workflow no longer relies on default token scopes.  
Best single fix without changing intended functionality: define workflow-level permissions with `contents: write` (needed for bump commit/tag/release operations). This keeps behavior working while making access explicit and constrained versus implicit defaults.

Change location:
- File: `.github/workflows/semver.yml`
- Insert directly after the `on:` trigger block and before `jobs:`.

No imports, methods, or extra definitions are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
