### PR TITLE
Fix pyproject to define optional-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ dependencies = [
 ]
 
 
+[project.optional-dependencies]
+STATA = ["stata-setup", "pystata"]
+R = []
+
 [dependency-groups]
 dev = [
     "pytest-cov>=6.0.0",
@@ -39,8 +43,6 @@ dev = [
     "pip-tools",
     "setuptools>=82.0.1",
 ]
-STATA = ["stata-setup", "pystata"]
-R = []
 
 
 [project.urls]


### PR DESCRIPTION
## Description

The STATA and R extras are defined under [dependency-groups] (line 42-43), but they need to be under [project.optional-dependencies] to be installable via pip's package[extra] syntax.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

